### PR TITLE
Update README.md, adding flags so docker build succeeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Credits go to the following:
    - Keep the TV on
 2. Build the application
    ```
-   docker build -t jellyfin .
+   docker build --network host -t jellyfin .
    ```
    If it fails to execute `expect.sh` in the last step, you might need to [download it again from here](https://github.com/babagreensheep/jellyfin-tizen-docker/blob/master/expect.sh) and overwrite the one in the directory from which you're building.
 3. Deploy the application to the TV:


### PR DESCRIPTION
Hiya! Super-useful repo since the site from the original reddit page is inaccessible. I had to add `--network host` in order to get the npm commands to complete, otherwise I would get the following error. I figured other folks would find it useful. Thx!

```
Step 24/32 : RUN npm ci --no-audit
 ---> Running in 906dffd9067a
npm ERR! cb() never called!

npm ERR! This is an error with npm itself. Please report this error at:
npm ERR!     <https://npm.community>

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/jellyfin/.npm/_logs/2023-01-04T01_52_21_112Z-debug.log
The command '/bin/sh -c npm ci --no-audit' returned a non-zero code: 1
```
