### PR TITLE
Jellyfin web build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,12 @@ RUN sed -i 's/\/home\/jellyfin\/tizen-studio-data\/tools\/certificate-generator\
 RUN git clone https://github.com/jellyfin/jellyfin-web.git /home/jellyfin/jellyfin-web
 RUN git clone https://github.com/jellyfin/jellyfin-tizen.git /home/jellyfin/jellyfin-tizen
 
-# Build apps
+# Build Jellyfin Web
 WORKDIR /home/jellyfin/jellyfin-web
 RUN npm ci --no-audit
+RUN npm run build:production
+
+# Build Jellyfin Tizen
 WORKDIR /home/jellyfin/jellyfin-tizen
 ENV JELLYFIN_WEB_DIR=/home/jellyfin/jellyfin-web/dist
 RUN npm ci --no-audit


### PR DESCRIPTION
First of all, thank you for providing this amazing repo. It helped me greatly!

While installing `jellyfin-tizen` on my TV I noticed Jellyfin Web is no longer being built via the `npm ci --no-audit` command, or at least not generating the built binaries in `/dist`. This breaks Jellyfin Tizen's build causing, in my case at least, [this problem](https://github.com/jellyfin/jellyfin-tizen/issues/128).

This PR addresses this problem by using `npm run build:production` to build the web client, which places the build artifacts in `/dist`, as expected.

I hope this helps other people!