### PR TITLE
Update nodejs to version 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,8 @@ RUN apt-get install -y curl
 RUN apt-get -y install expect
 
 # install node JS & update
-RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
 RUN apt-get install -y nodejs
-RUN npm update
 
 # Create user to install tizen-studio
 RUN useradd -m jellyfin -s /bin/bash


### PR DESCRIPTION
[jellyfin-tizen](https://github.com/jellyfin/jellyfin-tizen) now requires node 16+ and it was not building correctly for me with node 14. Updating nodejs fixed the issue (updated to 18 instead of 16 for future-proofing)