### PR TITLE
use Node version manager to install the latest version of Node.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get install -y curl
 RUN apt-get -y install expect
 
 # install node JS & update
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
-RUN apt-get install -y nodejs
+RUN apt-get install -y npm
+RUN npm install -g n && n latest && hash -r
 
 # Create user to install tizen-studio
 RUN useradd -m jellyfin -s /bin/bash


### PR DESCRIPTION
Instead of constantly updating the NodeSource installer, a Node version manager (in this case [n](https://github.com/tj/n)) can be used to ensure Node.js is always up to date. This is also the recommended install method in the official [documentation](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).